### PR TITLE
Fix Frontpage Search Issue #92

### DIFF
--- a/js/tosdr.js
+++ b/js/tosdr.js
@@ -17,6 +17,9 @@ $(function () {
         if (terms[j].substring(0, searchTerm.length) == searchTerm) {
           match = true;
           break;
+        } else if(terms[j].substring(0, searchTerm.length) == searchTerm.replace(" ", "-")) {
+          match = true;
+          break;
         }
       }
       if (match) {


### PR DESCRIPTION
The search feature for the frontpage only stores search terms with words separated by hyphens, not by spaces. This is why multiple-word searches weren't working.
