### PR TITLE
update spotify json to specify no rating

### DIFF
--- a/services/spotify.json
+++ b/services/spotify.json
@@ -28,7 +28,9 @@
             "url": "https://www.spotify.com/se/legal/unlimited-code-terms-and-conditions/"
         }
     }, 
-    "tosdr": {}, 
+    "tosdr": {
+		"rated": false
+	}, 
     "type": "service", 
     "url": "spotify.com"
 }


### PR DESCRIPTION
On the tosdr.org page, spotify's rating says "undefined." Added "rating": false to the spotify service.
