### PR TITLE
jump to a service's point directly (within modal), through URL hash ref.

### DIFF
--- a/js/tosdr.js
+++ b/js/tosdr.js
@@ -79,7 +79,6 @@ $(function () {
 
   if (location.hash.length > 1) {
     var hash = location.hash.substring(1);
-
     if (hash.indexOf("=") != -1) {
       var splits = hash.split("=");
       if (splits.length == 2 && splits[0] == "search" && splits[1].length > 0) {
@@ -90,6 +89,25 @@ $(function () {
         $('html, body').animate({
           scrollTop: $("#services").offset().top
         }, 1000);
+      } else if (splits.length == 2 && splits[0] == "servicePoint" && splits[1].length > 0) {
+        
+        // allows for directly referencing a service's point in URL
+          // ex.: https://tosdr.org/#servicePoint=google__lU-QhFXMOcU 
+          // hash syntax: /#servicePoint=<serviceName>__<pointId>
+          
+        if (splits[1].indexOf('__') != -1 && splits[1].split('__')[0].length > 0 && 
+            splits[1].split('__')[1].length > 0 ) {
+          var serviceName = splits[1].split('__')[0];
+          var pointId = splits[1].split('__')[1];
+          var serviceMatchBool = showModal(serviceName)
+          if (serviceMatchBool){
+            var subtractFromOffset = $(".modal-header").outerHeight() + $("#modal_" + serviceName).offset().top + 5
+            var offset = $("#popup-point-" + serviceName + "-" + pointId).offset().top
+            $('#modal_' + serviceName + ' .modal-body').animate({
+              scrollTop: offset - subtractFromOffset
+            }, 1000)
+          } 
+        }
       }
     } else {
       showModal(hash);


### PR DESCRIPTION
jump to a service's point directly (within modal), through URL hash reference
- allows for directly referencing a service's point in URL
- ex.: https://tosdr.org/#servicePoint=google__lU-QhFXMOcU
- hash syntax: /#servicePoint= serviceName __ pointId