### PR TITLE
Only include logos that actually exist

### DIFF
--- a/build/renderPages.js
+++ b/build/renderPages.js
@@ -104,7 +104,11 @@ function renderDetails(grunt, name, points, toslinks, obj) {
   grunt.log.writeln(toslinks);
   grunt.log.writeln(obj);
   //this renders one service (for instance 'Facebook' or 'Google') on our main index.html page:
-  var header = '<h3><img src="logo/' + name + '.png" class="favlogo"><a class="modal-link" data-service-name="' + name + '" href="#' + name + '">' + obj.name + '</a>\n';
+  var logo = '';
+  if (grunt.file.exists(grunt.config.get('conf').src, 'logo', `${name}.png`)) {
+    logo = `<img src="logo/${name}.png" class="favlogo">`;
+  }
+  var header = '<h3>' + logo + '<a class="modal-link" data-service-name="' + name + '" href="#' + name + '">' + obj.name + '</a>\n';
   var rating;
   if (!obj.tosdr) {
     obj.tosdr = {rated:false};
@@ -203,9 +207,13 @@ function renderPopup(grunt, name, obj, points, links) {
   var longName = obj.name,
     domain = obj.url,
     verdict = obj.tosdr.rated,
-    ratingText = getRatingText(obj.tosdr.rated);
+    ratingText = getRatingText(obj.tosdr.rated),
+    logo = '';
+  if (grunt.file.exists(grunt.config.get('conf').src, 'logo', `${name}.png`)) {
+    logo = `<img src="logo/${name}.png" alt="" class="pull-left favlogo" heigh="36">`;
+  }
   var headerHtml = '<div class="modal-header"><button data-dismiss="modal" class="close" type="button">×</button>' +
-			'<img src="logo/' + name + '.png" alt="" class="pull-left favlogo" height="36" >' +
+      logo +
 			'<h3>' + longName +
 			'<small class="service-url">Share review <input class="share-link" type="text" value="https://tosdr.org/#' + name + '" readonly /></small>' +
 			'</h3></div>\n';


### PR DESCRIPTION
Currently when loading the frontpage, the browser makes 942 requests. 742 of those are for logo images that don't actually exist, resulting in 404s and broken image icons next to the service names:

<img width="1063" alt="Screenshot 2020-08-01 at 19 33 43" src="https://user-images.githubusercontent.com/843/89107664-eb56a980-d432-11ea-9015-733ca893429f.png">


This PR checks if the logo file is actually available before including it on the generated page:

<img width="1038" alt="Screenshot 2020-08-01 at 19 34 00" src="https://user-images.githubusercontent.com/843/89107689-16d99400-d433-11ea-9513-1f10c220bd31.png">

This way the number of requests is reduced to 200 and no 404s.