### PR TITLE
fixed typo in tosdr.json

### DIFF
--- a/api/1/service/tosdr.json
+++ b/api/1/service/tosdr.json
@@ -152,6 +152,6 @@
     }
   },
   "urls": [
-    "tisdr.org"
+    "tosdr.org"
   ]
 }


### PR DESCRIPTION
in the urls section (line 155) there is a typo that doesn't causes the link to redirect to nothing instead of the tosdr.org